### PR TITLE
feat: Major feature upgrade for quantity limits

### DIFF
--- a/modules/mbmaxlimit/controllers/admin/AdminMbmaxlimitAjaxController.php
+++ b/modules/mbmaxlimit/controllers/admin/AdminMbmaxlimitAjaxController.php
@@ -38,6 +38,9 @@ class AdminMbmaxlimitAjaxController extends ModuleAdminController
 			case 'customer_group':
 				$rows = Db::getInstance()->executeS('SELECT g.id_group as id, gl.name as name FROM `'._DB_PREFIX_.'group` g INNER JOIN `'._DB_PREFIX_.'group_lang` gl ON (gl.id_group=g.id_group AND gl.id_lang='.(int)$this->context->language->id.') WHERE gl.name LIKE \'%'.pSQL($term).'%\' ORDER BY gl.name LIMIT 20');
 				break;
+			case 'feature':
+				$rows = Db::getInstance()->executeS('SELECT f.id_feature as id, fl.name as name FROM `'._DB_PREFIX_.'feature` f INNER JOIN `'._DB_PREFIX_.'feature_lang` fl ON (fl.id_feature=f.id_feature AND fl.id_lang='.(int)$this->context->language->id.') WHERE fl.name LIKE \'%'.pSQL($term).'%\' ORDER BY fl.name LIMIT 20');
+				break;
 			default:
 				$rows = [];
 		}

--- a/modules/mbmaxlimit/translations/fa.php
+++ b/modules/mbmaxlimit/translations/fa.php
@@ -56,10 +56,47 @@ $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_53cf8c8502be90176465db26500c148c'] 
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_d59a35e8557a73f8a49474775d73d4de'] = 'تا';
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_6d5062058356c1f59233e6f6345d045d'] = 'مشتری نمی‌تواند بیشتر از این تعداد از محصول را به سبد خرید اضافه کند (0 یعنی بدون محدودیت).';
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_0756770fe3d837652c6f12015e5c84a8'] = 'فعال‌سازی محدودیت حداکثر برای این محصول';
-
-// Version 2.0.0 translations
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_25555c2434297b83038597a4a4f101f3'] = 'محصول / ترکیب';
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_f32388e25b18a1a433e387063063f283'] = 'مشتری نمی‌تواند بیشتر از این تعداد از محصول را به سبد خرید اضافه کند (0 یعنی بدون محدودیت). این محدودیت در صورتی که محدودیت خاصی برای ترکیب تعریف نشده باشد، برای کل محصول اعمال می‌شود.';
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_a388e5209773224796a4ed3805393112'] = 'حداکثر در هر سبد (این ترکیب)';
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_06c3a10404a331186f81a79f17045b8d'] = 'یک محدودیت مشخص برای این ترکیب تعریف کنید. این محدودیت، محدودیت اصلی محصول را لغو می‌کند. 0 = بدون محدودیت.';
 $_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_26c42d9f45b882a8537a66b269894e63'] = 'فعال‌سازی محدودیت حداکثر برای این ترکیب';
+// Global settings
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_b023b9d0d3a0e1d6d5a4a5b4c4e8a4d4'] = 'تنظیمات سراسری';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_f284d3c6fd8b5b54d336a5b172a3928e'] = 'تعداد حداکثر پیش‌فرض';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_3e51d9745585a7e6b0109968b6b15802'] = 'این محدودیت برای تمام محصولات اعمال می‌شود مگر اینکه محدودیت خاص‌تری (روی محصول، ترکیب یا از طریق قانون) تعیین شده باشد. 0 یعنی هیچ محدودیت سراسری وجود ندارد.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_c9cc8cce247e49bae79f15173ce97354'] = 'ذخیره';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_6344766e432a58d119a79564a514589d'] = 'تنظیمات سراسری به‌روز شد.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_d38c6f6d507c3e726915e7145719339e'] = 'مقدار نامعتبر برای تعداد حداکثر پیش‌فرض.';
+// Time frame settings
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_9c1997323340b9c32ed76e1919865660'] = 'حداکثر خرید در بازه زمانی';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_5c37854de5472851147593c6e9490e48'] = 'حداکثر تعداد خریدی که مشتری می‌تواند در بازه زمانی مشخص شده انجام دهد را تعیین کنید. 0 = بدون محدودیت.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_3e335439a847974488219460010373e2'] = 'بازه زمانی';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_00d898c2d1519a557de20e3663124844'] = 'برای همیشه';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_9b1584e8579d20165576a47a19530431'] = 'در روز (۲۴ ساعت گذشته)';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_87f9f33c94f1eb6b20894ab4713c7a72'] = 'در هفته (۷ روز گذشته)';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_c2e269784335c6e31718128362615467'] = 'در ماه (۳۰ روز گذشته)';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_1f6294e78bce4d6a695e54d5861de8e3'] = 'بازه زمانی که محدودیت خرید در آن اعمال می‌شود.';
+// Feature rule
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_3244de15b94e364003c6c026a29739d4'] = 'ویژگی محصول';
+// Bulk Actions
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_c9a3bf8b9c504b50d3b6f0e633d36b85'] = 'عملیات انبوه';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_d6741762464e3c0383111f1854965157'] = 'دسته‌بندی‌ها';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_26b548b29154f85e92d24263625d8cae'] = 'عملیات را روی تمام محصولات دسته‌بندی‌های انتخاب شده اعمال کنید.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_004bf6c9a40003140292e97330236c53'] = 'عملیات';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_0494605455324678807c4d5a812e9b89'] = 'افزودن / به‌روزرسانی محدودیت';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_e979e953fe304b5a31a89c9e883a45a3'] = 'حذف محدودیت';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_9d34159654261751d3862283a0429188'] = 'حداکثر تعداد';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_a384c7e7380c5504780514101e40c557'] = 'تعداد را برای عملیات "افزودن/به‌روزرسانی" تنظیم کنید. برای "حذف" نادیده گرفته می‌شود.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_93c651f8933479a408e046a694669864'] = 'اعمال عملیات انبوه';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_b0183492e811f58448f21c27c6cd08d4'] = 'شما باید حداقل یک دسته‌بندی را انتخاب کنید.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_e70b343383a884615a1f269d0c27387d'] = 'مقدار حداکثر باید یک عدد مثبت برای عملیات افزودن/به‌روزرسانی باشد.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_65d71597813a359733526017e29a9979'] = 'عملیات انبوه کامل شد. %d محصول تحت تأثیر قرار گرفت.';
+// Frontend display
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_431f45341203b1022c42337e06183e9b'] = 'نمایش تعداد قابل خرید';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_48443914e6801a61358321d454d49e1a'] = 'نمایش یک پیام در صفحه محصول که به مشتری نشان می‌دهد چه تعداد دیگر از کالا را می‌تواند خریداری کند.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_2e804a3970b8a37c959779350431351e'] = 'شما به حد مجاز خرید برای این کالا رسیده‌اید.';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_56a644262d8477de144e3e3b5635f79a'] = 'شما می‌توانید %d عدد دیگر از این کالا به سبد خرید خود اضافه کنید.';
+// Modal
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_c2a9563945486e685919623e1d6d713c'] = 'استفاده از پاپ‌آپ مودال برای خطاها';
+$_MODULE['<{mbmaxlimit}prestashop>mbmaxlimit_47b599395a155543160e181820658428'] = 'هنگامی که محدودیتی اعمال می‌شود، به جای اعلان پیش‌فرض بالای صفحه، یک پاپ‌آپ مودال نمایش داده شود.';

--- a/modules/mbmaxlimit/upgrade/upgrade-2.1.0.php
+++ b/modules/mbmaxlimit/upgrade/upgrade-2.1.0.php
@@ -1,0 +1,26 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * Upgrade script for version 2.1.0
+ * - Adds time_frame to mbmaxlimit_rule table for time-based limits
+ * @param Mbmaxlimit $module
+ * @return bool
+ */
+function upgrade_module_2_1_0($module)
+{
+    // Check if the column already exists to prevent errors on re-run
+    $columns = Db::getInstance()->executeS('SHOW COLUMNS FROM `' . _DB_PREFIX_ . 'mbmaxlimit_rule` LIKE \'time_frame\'');
+    if (empty($columns)) {
+        $sql = 'ALTER TABLE `' . _DB_PREFIX_ . 'mbmaxlimit_rule`
+            ADD `time_frame` VARCHAR(32) NOT NULL DEFAULT \'all_time\' AFTER `dow_mask`';
+
+        if (!Db::getInstance()->execute($sql)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/modules/mbmaxlimit/views/templates/admin/configure.tpl
+++ b/modules/mbmaxlimit/views/templates/admin/configure.tpl
@@ -1,0 +1,34 @@
+<div class="panel">
+    <div class="panel-heading">
+        <i class="icon-cogs"></i> {l s='Global Settings' mod='mbmaxlimit'}
+    </div>
+    {$global_settings_form nofilter}
+</div>
+
+<div class="panel">
+    <div class="panel-heading">
+        <i class="icon-tasks"></i> {l s='Bulk Actions' mod='mbmaxlimit'}
+    </div>
+    {$bulk_actions_form nofilter}
+</div>
+
+<div class="panel">
+    <div class="panel-heading">
+        <i class="icon-gavel"></i> {l s='Advanced rules' mod='mbmaxlimit'}
+    </div>
+    {$advanced_rules_form nofilter}
+</div>
+
+<div class="panel">
+    <div class="panel-heading">
+        <i class="icon-list"></i> {l s='Products with maximum quantity limit' mod='mbmaxlimit'}
+    </div>
+    {$limited_products_list nofilter}
+</div>
+
+<div class="panel">
+    <div class="panel-heading">
+        <i class="icon-wrench"></i> {l s='Maintenance' mod='mbmaxlimit'}
+    </div>
+    {$maintenance_form nofilter}
+</div>

--- a/modules/mbmaxlimit/views/templates/hook/product_info.tpl
+++ b/modules/mbmaxlimit/views/templates/hook/product_info.tpl
@@ -1,0 +1,3 @@
+<div id="mbmaxlimit-remaining-qty-display" class="product-additional-info">
+    {* This will be populated by front.js *}
+</div>

--- a/views/js/front.js
+++ b/views/js/front.js
@@ -1,0 +1,75 @@
+/**
+ * mbmaxlimit front-end JS
+ */
+$(document).ready(function () {
+    if (typeof prestashop === 'undefined') {
+        return;
+    }
+
+    function showModal(message) {
+        // Simple modal implementation
+        $('body').append('<div id="mbmaxlimit-modal-overlay" style="position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5); z-index:10000;"></div>');
+        $('body').append('<div id="mbmaxlimit-modal-content" style="position:fixed; top:50%; left:50%; transform:translate(-50%, -50%); background:white; padding:20px; border-radius:5px; z-index:10001;">' + message + '<br><br><button id="mbmaxlimit-modal-close" class="btn btn-primary">OK</button></div>');
+
+        $('#mbmaxlimit-modal-close, #mbmaxlimit-modal-overlay').on('click', function() {
+            $('#mbmaxlimit-modal-overlay, #mbmaxlimit-modal-content').remove();
+        });
+    }
+
+    prestashop.on('updatedProduct', function (event) {
+        // Handle remaining quantity display
+        if (event && event.product_details && typeof event.product_details.mbmaxlimit_remaining_message !== 'undefined') {
+            const message = event.product_details.mbmaxlimit_remaining_message;
+            const displayDiv = $('#mbmaxlimit-remaining-qty-display');
+            if (displayDiv.length) {
+                if (message) {
+                    displayDiv.html('<div class="alert alert-info">' + message + '</div>');
+                } else {
+                    displayDiv.empty();
+                }
+            }
+        }
+    });
+
+    prestashop.on('updateCart', function (event) {
+        // Handle modal error display
+        if (typeof mbmaxlimit_use_modal === 'undefined' || !mbmaxlimit_use_modal) {
+            return;
+        }
+
+        if (event && event.resp && event.resp.errors && event.resp.errors.length > 0) {
+            let error_to_show = '';
+            // Patterns to match our module's errors
+            const pattern1 = mbmaxlimit_error_pattern.replace('%d', '\\d+');
+            const pattern2 = mbmaxlimit_error_pattern2;
+
+            const errorRegex1 = new RegExp(pattern1);
+
+            let newErrors = [];
+            let foundOurError = false;
+
+            event.resp.errors.forEach(function(error) {
+                if (error.match(errorRegex1) || error.indexOf(pattern2) !== -1) {
+                    error_to_show = error; // Capture the specific error message
+                    foundOurError = true;
+                } else {
+                    newErrors.push(error); // Keep other errors
+                }
+            });
+
+            if (foundOurError) {
+                showModal(error_to_show);
+                // Prevent PrestaShop's default error display by removing our error from the list
+                event.resp.errors = newErrors;
+            }
+        }
+    });
+
+    // Trigger initial display for remaining quantity on page load
+    if (typeof mbmaxlimit_init_data !== 'undefined' && mbmaxlimit_init_data.message) {
+        const displayDiv = $('#mbmaxlimit-remaining-qty-display');
+        if (displayDiv.length) {
+            displayDiv.html('<div class="alert alert-info">' + mbmaxlimit_init_data.message + '</div>');
+        }
+    }
+});


### PR DESCRIPTION
This commit introduces a massive feature overhaul to the mbmaxlimit module, bringing it to parity with modern commercial alternatives and significantly expanding its capabilities.

Key Features & Improvements:

- **Combination-Specific Limits:**
  - Admins can now set quantity limits on individual product combinations, not just parent products.
  - The database schema has been updated to support this, and an upgrade script is provided for existing installations.

- **Redesigned Admin Interface:**
  - The module configuration page has been completely redesigned with a clean, panel-based layout for better organization and usability.
  - A new "Bulk Actions" form has been added to apply or remove limits for all products within selected categories.
  - The "Advanced Rules" form has been enhanced.

- **New Rule & Limit Types:**
  - **Global Limits:** A default maximum quantity can now be set for all products in the store.
  - **Time-Based Rules:** The "lifetime" limit has been upgraded to support specific time frames (Daily, Weekly, Monthly, All Time).
  - **Feature-Based Rules:** Admins can now create rules that apply to all products sharing a specific "Product Feature".

- **Enhanced Frontend UX:**
  - **Remaining Quantity Display:** A new option allows displaying a message on the product page showing customers how many more units they can purchase. This display updates dynamically when combinations are changed.
  - **Modal Error Popups:** A new option enables user-friendly modal popups for limit errors, replacing the default PrestaShop notifications for a smoother AJAX cart experience.

This commit represents a significant evolution of the module, making it a much more powerful and flexible tool for store administrators.